### PR TITLE
경북대 BE_안용진 2주차 과제(1단계)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # spring-gift-wishlist
 
+# step1
+***
+## 구현할 기능 목록
+- ProductRecord에 BeanValidation 적용
+- MethodArgumentNotValidException 예외 처리 핸들러 추가
+- 어드민 페이지에서 400 Bad Request 응답 처리 구현
+

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     runtimeOnly 'com.h2database:h2'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/gift/controller/ProductController.java
+++ b/src/main/java/gift/controller/ProductController.java
@@ -2,6 +2,7 @@ package gift.controller;
 
 import gift.model.ProductRecord;
 import gift.repository.ProductDAO;
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +26,7 @@ public class ProductController {
     }
 
     @PostMapping("/products")
-    public ResponseEntity<ProductRecord> addProduct(@RequestBody ProductRecord product) {
+    public ResponseEntity<ProductRecord> addProduct(@Valid @RequestBody ProductRecord product) {
         ProductRecord result = productDAO.addNewRecord(product);
 
         return makeCreatedResponse(result);
@@ -39,7 +40,7 @@ public class ProductController {
     }
 
     @PutMapping("/products/{id}")
-    public ResponseEntity<ProductRecord> updateProduct(@PathVariable int id, @RequestBody ProductRecord product) {
+    public ResponseEntity<ProductRecord> updateProduct(@PathVariable int id, @Valid @RequestBody ProductRecord product) {
         ProductRecord result;
         try {
             result = productDAO.replaceRecord(id, product);
@@ -53,7 +54,7 @@ public class ProductController {
     }
 
     @PatchMapping("/products/{id}")
-    public ResponseEntity<ProductRecord> updateProductPartially(@PathVariable int id, @RequestBody ProductRecord patch) {
+    public ResponseEntity<ProductRecord> updateProductPartially(@PathVariable int id, @Valid @RequestBody ProductRecord patch) {
         return ResponseEntity.ok(productDAO.updateRecord(id, patch));
     }
 

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -24,7 +24,8 @@ public class GlobalExceptionHandler {
         e.getBindingResult().getAllErrors().forEach((error) -> {
             String fieldName = ((FieldError) error).getField();
             String errorMessage = error.getDefaultMessage();
-            errors.put(fieldName, errorMessage);
+
+            errors.merge(fieldName, errorMessage, (existingMessage, newMessage) -> existingMessage + "\n" + newMessage);
         });
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }

--- a/src/main/java/gift/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gift/exception/GlobalExceptionHandler.java
@@ -2,9 +2,13 @@ package gift.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 @RestControllerAdvice
@@ -12,6 +16,17 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<String> handleNoResource(NoSuchElementException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/gift/model/ProductRecord.java
+++ b/src/main/java/gift/model/ProductRecord.java
@@ -8,6 +8,7 @@ public record ProductRecord(
 
         @Pattern(regexp =  "^[a-zA-Z0-9가-힣 ()\\[\\]+\\-&/_]{1,15}$", message = "이름은 1 ~ 15자 사이여야 하며, 특수 문자는 허용된 특수 문자만 가능합니다. " +
                 "\n허용된 특수문자 : [, ], (, ), +, -, &, /, _ ")
+        @Pattern(regexp = "^(?!.*카카오).*$", message = "'카카오'가 포함된 상품은 md만 추가할 수 있습니다. 담당 md와 협의해주세요.")
         String name,
 
         @Max(value = Integer.MAX_VALUE, message = "가격은 " + Integer.MAX_VALUE + "를 넘을 수 없습니다.")

--- a/src/main/java/gift/model/ProductRecord.java
+++ b/src/main/java/gift/model/ProductRecord.java
@@ -1,6 +1,22 @@
 package gift.model;
 
-public record ProductRecord(long id, String name, int price, String imageUrl) {
+import jakarta.validation.constraints.*;
+import org.hibernate.validator.constraints.URL;
+
+public record ProductRecord(
+        long id,
+
+        @Pattern(regexp =  "^[a-zA-Z0-9가-힣 ()\\[\\]+\\-&/_]{1,15}$", message = "이름은 1 ~ 15자 사이여야 하며, 특수 문자는 허용된 특수 문자만 가능합니다. " +
+                "\n허용된 특수문자 : [, ], (, ), +, -, &, /, _ ")
+        String name,
+
+        @Max(value = Integer.MAX_VALUE, message = "가격은 " + Integer.MAX_VALUE + "를 넘을 수 없습니다.")
+        @Min(value = 0, message = "가격은 음수가 될 수 없습니다.")
+        int price,
+
+        @URL(message = "유효한 imageUrl을 입력하세요")
+        String imageUrl
+) {
     public ProductRecord withId(long id) {
         return new ProductRecord(id, name, price, imageUrl);
     }
@@ -23,3 +39,5 @@ public record ProductRecord(long id, String name, int price, String imageUrl) {
         return new ProductRecord(id, newName, newPrice, newImageUrl);
     }
 }
+
+

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -56,7 +56,10 @@
                 alert("상품 삭제가 완료되었습니다.")
                 window.location.href = '/';
             } else {
-                alert('Error: ' + response.statusText);
+                response.text().then(errmsg => {
+                    alert(errmsg);
+                })
+
             }
         })
     }

--- a/src/main/resources/templates/product_add.html
+++ b/src/main/resources/templates/product_add.html
@@ -11,14 +11,17 @@
     <div>
         <label for="name">Product Name:</label>
         <input type="text" id="name" />
+        <span class="error-message" id="name-error" style="display:none; color:red;"></span>
     </div>
     <div>
         <label for="price">Price:</label>
         <input type="number" id="price" />
+        <span class="error-message" id="price-error" style="display:none; color:red;"></span>
     </div>
     <div>
         <label for="imageUrl">Image URL:</label>
         <input type="text" id="imageUrl" />
+        <span class="error-message" id="imageUrl-error" style="display:none; color:red;"></span>
     </div>
     <div>
         <button type="submit" id="submit-btn" onclick="add_product()">Add!</button>
@@ -49,9 +52,24 @@
             },
             body: body_data
         }).then(response => {
+            ["name", "price", "imageUrl"].forEach((field) => {
+                let $errorSupport = document.getElementById(field + "-error");
+
+                $errorSupport.textContent = "";
+                $errorSupport.style.display = "none";
+            })
             if (response.ok) {
                 alert("상품 추가가 완료되었습니다.")
                 window.location.href = '/';
+            } else if (response.status === 400){
+                response.json().then(invalidDict => {
+                    Object.entries(invalidDict).forEach(([field, errmsg]) => {
+                        let $errorSupport = document.getElementById(field + "-error");
+
+                        $errorSupport.textContent += "\n" + errmsg;
+                        $errorSupport.style.display = "";
+                    })
+                })
             } else {
                 response.text().then(errmsg => {
                     alert(errmsg);

--- a/src/main/resources/templates/product_add.html
+++ b/src/main/resources/templates/product_add.html
@@ -53,7 +53,9 @@
                 alert("상품 추가가 완료되었습니다.")
                 window.location.href = '/';
             } else {
-                alert('Error: ' + response.statusText);
+                response.text().then(errmsg => {
+                    alert(errmsg);
+                })
             }
         })
     }

--- a/src/main/resources/templates/product_edit.html
+++ b/src/main/resources/templates/product_edit.html
@@ -48,7 +48,9 @@
                 alert("수정이 완료되었습니다.")
                 window.location.href = '/';
             } else {
-                alert('Error: ' + response.statusText);
+                response.text().then(errmsg => {
+                    alert(errmsg);
+                })
             }
         })
     }

--- a/src/main/resources/templates/product_edit.html
+++ b/src/main/resources/templates/product_edit.html
@@ -11,14 +11,17 @@
     <div>
         <label for="name">Product Name:</label>
         <input type="text" id="name" th:placeholder="${product.name}"/>
+        <span class="error-message" id="name-error" style="display:none; color:red;"></span>
     </div>
     <div>
         <label for="price">Price:</label>
         <input type="number" id="price" th:placeholder="${product.price}"/>
+        <span class="error-message" id="price-error" style="display:none; color:red;"></span>
     </div>
     <div>
         <label for="imageUrl">Image URL:</label>
         <input type="text" id="imageUrl" th:placeholder="${product.imageUrl}"/>
+        <span class="error-message" id="imageUrl-error" style="color:red;"></span>
     </div>
     <div>
         <button type="submit" id="save-btn" th:onclick="'fetch_product(' + ${product.id} + ')'">Edit!</button>
@@ -44,9 +47,24 @@
             },
             body: body_data
         }).then(response => {
+            ["name", "price", "imageUrl"].forEach((field) => {
+                let $errorSupport = document.getElementById(field + "-error");
+
+                $errorSupport.textContent = ""
+                $errorSupport.style.display = "none";
+            })
             if (response.ok) {
-                alert("수정이 완료되었습니다.")
+                alert("상품 추가가 완료되었습니다.")
                 window.location.href = '/';
+            } else if (response.status === 400){
+                response.json().then(invalidDict => {
+                    Object.entries(invalidDict).forEach(([field, errmsg]) => {
+                        let $errorSupport = document.getElementById(field + "-error");
+
+                        $errorSupport.textContent += "\n" + errmsg;
+                        $errorSupport.style.display = "";
+                    })
+                })
             } else {
                 response.text().then(errmsg => {
                     alert(errmsg);

--- a/src/main/resources/templates/product_edit.html
+++ b/src/main/resources/templates/product_edit.html
@@ -54,7 +54,7 @@
                 $errorSupport.style.display = "none";
             })
             if (response.ok) {
-                alert("상품 추가가 완료되었습니다.")
+                alert("수정이 완료되었습니다.")
                 window.location.href = '/';
             } else if (response.status === 400){
                 response.json().then(invalidDict => {


### PR DESCRIPTION
## 어려웠던 점
***
과제의 요구사항 중,  '"카카오"가 포함된 문구는 담당 MD와 협의한 경우에만 사용할 수 있다.' 의 의미를 해석하고, 구현해보는 과정에서 시간이 많이 걸렸습니다.
'카카오'가 들어 갔을 때, 요청을 accept 만 하고 실제 동작은 하지 않다가 admin에서 허가 했을 때 실제 요청이 동작되도록 하는 기능을 구현해보다 실패하여 폐기하였습니다. 
다음 과제를 살펴보니 로그인 기능을 구현하는 과제이기에, 로그인 기능을 구현하고 나면 사용자 기반으로 상품 추가 여부를 구분할 수 있을 것 같아, 우선은 "카카오"라는 문구가 들어갔을 때 유효성 검사가 실패하도록만 구현해 두었습니다.

## 궁금한 점
저는  Bean Validation 어노테이션만 사용해 유효성 검사가 진행되도록 해 놓았지만, 
나중에 로그인을 구현한 뒤, 관리자 권한이 있으면 '카카오' 들어간 상품명이 허용되고, 일반 사용자는 '카카오'가 들어간 상품명은 유효성 검사에서 실패하게 하려면, 해당 유효성 검사 과정을 메서드로 빼 두어야 가능할 것 같다는 생각이 듭니다. 
혹시 메서드로 따로 빼 두지 않아도 권한에 따라 유효성 검사를 다르게 진행할 수 있는 방법도 존재하나요?